### PR TITLE
Security upgrade setuptools from 40.5.0 to 70.0.0

### DIFF
--- a/GrpcInterface/Python/requirements.txt
+++ b/GrpcInterface/Python/requirements.txt
@@ -3,3 +3,4 @@ grpcio-tools
 protobuf
 wheel
 typing-extensions
+setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Fixed vulnerability in the pip dependencies : `GrpcInterface/Python/requirements.txt`